### PR TITLE
refactor: delegate user data to user-service in auth-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 This project is a microservice-based backend. The `auth-service` handles authentication
 and delegates all user data operations to the separate `user-service` via a Feign client.
-Only the `user-service` owns the `users` table and related persistence logic.
+It issues JWT access and refresh tokens after verifying credentials through the
+`user-service`. Only the `user-service` owns the `users` table and related persistence
+logic.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # abc-interview-support-backend
-# backend-microservice-interview
+
+This project is a microservice-based backend. The `auth-service` handles authentication
+and delegates all user data operations to the separate `user-service` via a Feign client.
+Only the `user-service` owns the `users` table and related persistence logic.

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -42,22 +42,11 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 
-		<!-- JPA + PostgreSQL -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-
-		<!-- Security -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
+                <!-- Security -->
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
 
 		<!-- Validation -->
 		<dependency>

--- a/auth-service/src/main/java/com/auth/service/AuthServiceApplication.java
+++ b/auth-service/src/main/java/com/auth/service/AuthServiceApplication.java
@@ -2,8 +2,10 @@ package com.auth.service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class AuthServiceApplication {
 
 	public static void main(String[] args) {

--- a/auth-service/src/main/java/com/auth/service/client/UserClient.java
+++ b/auth-service/src/main/java/com/auth/service/client/UserClient.java
@@ -1,0 +1,13 @@
+package com.auth.service.client;
+
+import com.auth.service.dto.UserDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+    @GetMapping("/users/{id}")
+    UserDto getUserById(@PathVariable("id") Long id);
+}

--- a/auth-service/src/main/java/com/auth/service/client/UserClient.java
+++ b/auth-service/src/main/java/com/auth/service/client/UserClient.java
@@ -1,13 +1,19 @@
 package com.auth.service.client;
 
+import com.auth.service.dto.LoginRequest;
 import com.auth.service.dto.UserDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "user-service")
 public interface UserClient {
 
     @GetMapping("/users/{id}")
     UserDto getUserById(@PathVariable("id") Long id);
+
+    @PostMapping("/users/login")
+    UserDto login(@RequestBody LoginRequest request);
 }

--- a/auth-service/src/main/java/com/auth/service/controller/AuthController.java
+++ b/auth-service/src/main/java/com/auth/service/controller/AuthController.java
@@ -1,12 +1,18 @@
 package com.auth.service.controller;
 
+import com.auth.service.dto.LoginRequest;
+import com.auth.service.dto.RefreshRequest;
+import com.auth.service.dto.TokenResponse;
 import com.auth.service.dto.UserDto;
 import com.auth.service.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/auth")
@@ -18,5 +24,15 @@ public class AuthController {
     @GetMapping("/users/{id}")
     public UserDto getUserById(@PathVariable Long id) {
         return authService.getUserById(id);
+    }
+
+    @PostMapping("/login")
+    public TokenResponse login(@Valid @RequestBody LoginRequest request) {
+        return authService.login(request);
+    }
+
+    @PostMapping("/refresh")
+    public TokenResponse refresh(@Valid @RequestBody RefreshRequest request) {
+        return authService.refresh(request);
     }
 }

--- a/auth-service/src/main/java/com/auth/service/controller/AuthController.java
+++ b/auth-service/src/main/java/com/auth/service/controller/AuthController.java
@@ -1,0 +1,22 @@
+package com.auth.service.controller;
+
+import com.auth.service.dto.UserDto;
+import com.auth.service.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @GetMapping("/users/{id}")
+    public UserDto getUserById(@PathVariable Long id) {
+        return authService.getUserById(id);
+    }
+}

--- a/auth-service/src/main/java/com/auth/service/dto/LoginRequest.java
+++ b/auth-service/src/main/java/com/auth/service/dto/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.auth.service.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+
+    @Email
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String password;
+}
+

--- a/auth-service/src/main/java/com/auth/service/dto/RefreshRequest.java
+++ b/auth-service/src/main/java/com/auth/service/dto/RefreshRequest.java
@@ -1,0 +1,13 @@
+package com.auth.service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.Data;
+
+@Data
+public class RefreshRequest {
+
+    @NotBlank
+    private String refreshToken;
+}
+

--- a/auth-service/src/main/java/com/auth/service/dto/TokenResponse.java
+++ b/auth-service/src/main/java/com/auth/service/dto/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.auth.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}
+

--- a/auth-service/src/main/java/com/auth/service/dto/UserDto.java
+++ b/auth-service/src/main/java/com/auth/service/dto/UserDto.java
@@ -1,0 +1,10 @@
+package com.auth.service.dto;
+
+import lombok.Data;
+
+@Data
+public class UserDto {
+    private Long id;
+    private String email;
+    private String fullName;
+}

--- a/auth-service/src/main/java/com/auth/service/dto/UserDto.java
+++ b/auth-service/src/main/java/com/auth/service/dto/UserDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class UserDto {
     private Long id;
+    private Long roleId;
     private String email;
     private String fullName;
 }

--- a/auth-service/src/main/java/com/auth/service/service/AuthService.java
+++ b/auth-service/src/main/java/com/auth/service/service/AuthService.java
@@ -1,0 +1,17 @@
+package com.auth.service.service;
+
+import com.auth.service.client.UserClient;
+import com.auth.service.dto.UserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserClient userClient;
+
+    public UserDto getUserById(Long id) {
+        return userClient.getUserById(id);
+    }
+}

--- a/auth-service/src/main/java/com/auth/service/service/AuthService.java
+++ b/auth-service/src/main/java/com/auth/service/service/AuthService.java
@@ -1,6 +1,9 @@
 package com.auth.service.service;
 
 import com.auth.service.client.UserClient;
+import com.auth.service.dto.LoginRequest;
+import com.auth.service.dto.RefreshRequest;
+import com.auth.service.dto.TokenResponse;
 import com.auth.service.dto.UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,8 +13,25 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final UserClient userClient;
+    private final JwtService jwtService;
 
     public UserDto getUserById(Long id) {
         return userClient.getUserById(id);
+    }
+
+    public TokenResponse login(LoginRequest request) {
+        UserDto user = userClient.login(request);
+        String access = jwtService.generateAccessToken(user);
+        String refresh = jwtService.generateRefreshToken(user);
+        return new TokenResponse(access, refresh);
+    }
+
+    public TokenResponse refresh(RefreshRequest request) {
+        String token = request.getRefreshToken();
+        Long userId = Long.valueOf(jwtService.parse(token).getSubject());
+        UserDto user = userClient.getUserById(userId);
+        String access = jwtService.generateAccessToken(user);
+        String refresh = jwtService.generateRefreshToken(user);
+        return new TokenResponse(access, refresh);
     }
 }

--- a/auth-service/src/main/java/com/auth/service/service/JwtService.java
+++ b/auth-service/src/main/java/com/auth/service/service/JwtService.java
@@ -1,0 +1,67 @@
+package com.auth.service.service;
+
+import com.auth.service.dto.UserDto;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-minutes}")
+    private long accessMinutes;
+
+    @Value("${jwt.refresh-days}")
+    private long refreshDays;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(UserDto user) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .claim("roleId", user.getRoleId())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(accessMinutes, ChronoUnit.MINUTES)))
+                .signWith(key)
+                .compact();
+    }
+
+    public String generateRefreshToken(UserDto user) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(user.getId()))
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(refreshDays, ChronoUnit.DAYS)))
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims parse(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}
+

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -4,15 +4,6 @@ server:
 spring:
   application:
     name: auth-service
-  datasource:
-    url: jdbc:postgresql://postgres:5432/authdb
-    username: postgres
-    password: 123456
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
 
   mail:
     host: smtp.gmail.com

--- a/auth-service/src/test/java/com/auth/service/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/auth/service/AuthServiceApplicationTests.java
@@ -3,7 +3,11 @@ package com.auth.service;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = {
+        "spring.cloud.config.enabled=false",
+        "spring.cloud.discovery.enabled=false",
+        "eureka.client.enabled=false"
+})
 class AuthServiceApplicationTests {
 
 	@Test

--- a/config-repo/auth-service.yml
+++ b/config-repo/auth-service.yml
@@ -4,15 +4,6 @@ server:
 spring:
   application:
     name: auth-service
-  datasource:
-    url: jdbc:postgresql://postgres:5432/authdb
-    username: postgres
-    password: 123456
-    driver-class-name: org.postgresql.Driver
-  jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
 
   mail:
     host: smtp.gmail.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,6 @@ services:
       # Nếu KHÔNG dùng config-repo, truyền trực tiếp (ví dụ):
       # SPRING_APPLICATION_NAME: auth-service
       # EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE: http://discovery-service:8761/eureka
-      # SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/authdb
-      # SPRING_DATASOURCE_USERNAME: postgres
-      # SPRING_DATASOURCE_PASSWORD: 123456
-      # SPRING_JPA_HIBERNATE_DDL_AUTO: update
       # spring.mail.* / jwt.* / app.base-url cũng có thể truyền qua env
     depends_on:
       postgres:

--- a/init.sql
+++ b/init.sql
@@ -1,5 +1,4 @@
 CREATE DATABASE userservice;
-CREATE DATABASE authdb;
 CREATE DATABASE examdb;
 CREATE DATABASE questiondb;
 CREATE DATABASE careerdb;

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -67,8 +67,14 @@
 			<artifactId>mapstruct</artifactId>
 			<version>1.5.5.Final</version>
 		</dependency>
+                <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>1.5.5.Final</version>
+                        <scope>provided</scope>
+                </dependency>
 
-		<!-- Config Client (lấy cấu hình từ Config Server nếu bạn dùng) -->
+                <!-- Config Client (lấy cấu hình từ Config Server nếu bạn dùng) -->
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-config</artifactId>
@@ -142,7 +148,12 @@
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 						</path>
-					</annotationProcessorPaths>
+                                                <path>
+                                                        <groupId>org.mapstruct</groupId>
+                                                        <artifactId>mapstruct-processor</artifactId>
+                                                        <version>1.5.5.Final</version>
+                                                </path>
+                                        </annotationProcessorPaths>
 				</configuration>
 			</plugin>
 

--- a/user-service/src/main/java/com/abc/user_service/controller/UserController.java
+++ b/user-service/src/main/java/com/abc/user_service/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.abc.user_service.controller;
+
+import com.abc.user_service.dto.request.*;
+import com.abc.user_service.dto.response.UserResponse;
+import com.abc.user_service.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping
+    public UserResponse create(@Valid @RequestBody UserRequest request) {
+        return userService.create(request);
+    }
+
+    @GetMapping("/{id}")
+    public UserResponse getById(@PathVariable Long id) {
+        return userService.getById(id);
+    }
+
+    @PostMapping("/login")
+    public UserResponse login(@Valid @RequestBody LoginRequest request) {
+        return userService.login(request);
+    }
+
+    @PostMapping("/verify")
+    public UserResponse verify(@Valid @RequestBody VerifyRequest request) {
+        return userService.verify(request);
+    }
+
+    @PutMapping("/{id}/role")
+    public UserResponse updateRole(@PathVariable Long id, @Valid @RequestBody RoleUpdateRequest request) {
+        return userService.updateRole(id, request);
+    }
+
+    @PutMapping("/{id}/status")
+    public UserResponse updateStatus(@PathVariable Long id, @Valid @RequestBody StatusUpdateRequest request) {
+        return userService.updateStatus(id, request);
+    }
+
+    @PostMapping("/elo")
+    public UserResponse applyElo(@Valid @RequestBody EloApplyRequest request) {
+        return userService.applyElo(request);
+    }
+}

--- a/user-service/src/main/java/com/abc/user_service/service/UserService.java
+++ b/user-service/src/main/java/com/abc/user_service/service/UserService.java
@@ -1,0 +1,98 @@
+package com.abc.user_service.service;
+
+import com.abc.user_service.dto.request.*;
+import com.abc.user_service.dto.response.UserResponse;
+import com.abc.user_service.entity.*;
+import com.abc.user_service.mapper.UserMapper;
+import com.abc.user_service.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final EloHistoryRepository eloHistoryRepository;
+    private final UserMapper userMapper;
+
+    public UserResponse create(UserRequest request) {
+        User user = userMapper.toEntity(request);
+        Role role = roleRepository.findById(request.getRoleId())
+                .orElseThrow(() -> new RuntimeException("Role not found"));
+        user.setRole(role);
+        user.setStatus(UserStatus.PENDING);
+        user.setEloScore(0);
+        user.setEloRank(EloRank.NEWBIE);
+        user.setCreatedAt(LocalDateTime.now());
+        return userMapper.toResponse(userRepository.save(user));
+    }
+
+    public UserResponse getById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return userMapper.toResponse(user);
+    }
+
+    public UserResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .filter(u -> u.getPassword().equals(request.getPassword()))
+                .orElseThrow(() -> new RuntimeException("Invalid credentials"));
+        return userMapper.toResponse(user);
+    }
+
+    public UserResponse verify(VerifyRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        user.setStatus(UserStatus.VERIFIED);
+        return userMapper.toResponse(userRepository.save(user));
+    }
+
+    public UserResponse updateRole(Long userId, RoleUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        Role role = roleRepository.findById(request.getRoleId())
+                .orElseThrow(() -> new RuntimeException("Role not found"));
+        user.setRole(role);
+        return userMapper.toResponse(userRepository.save(user));
+    }
+
+    public UserResponse updateStatus(Long userId, StatusUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        user.setStatus(request.getStatus());
+        return userMapper.toResponse(userRepository.save(user));
+    }
+
+    public UserResponse applyElo(EloApplyRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        int score = user.getEloScore() == null ? 0 : user.getEloScore();
+        score += request.getPoints();
+        user.setEloScore(score);
+        user.setEloRank(calculateRank(score));
+
+        EloHistory history = new EloHistory();
+        history.setUser(user);
+        history.setAction(request.getAction());
+        history.setPoints(request.getPoints());
+        history.setDescription(request.getDescription());
+        history.setCreatedAt(LocalDateTime.now());
+        eloHistoryRepository.save(history);
+
+        return userMapper.toResponse(userRepository.save(user));
+    }
+
+    private EloRank calculateRank(int score) {
+        if (score < 100) return EloRank.NEWBIE;
+        if (score < 200) return EloRank.LEARNER;
+        if (score < 400) return EloRank.CONTRIBUTOR;
+        if (score < 700) return EloRank.SOLVER;
+        if (score < 1100) return EloRank.EXPERT;
+        if (score < 1600) return EloRank.SENIOR_EXPERT;
+        if (score < 2100) return EloRank.MASTER;
+        return EloRank.LEGEND;
+    }
+}


### PR DESCRIPTION
## Summary
- remove local user persistence from auth-service and configure Feign client
- update configuration, docs and compose setup to rely on user-service for user data
- drop authdb creation from init script

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aebe7befc0832eb1cc68cdef00651d